### PR TITLE
CI: Remove vanilla sandbox

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,4 @@
 {
   "packages": ["./"],
-  "sandboxes": ["new", "/examples/simple-inside"]
+  "sandboxes": ["/examples/simple-inside"]
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,4 @@
 {
   "packages": ["./"],
-  "sandboxes": ["new", "vanilla", "/examples/simple-inside"]
+  "sandboxes": ["new", "/examples/simple-inside"]
 }


### PR DESCRIPTION
As this is explicitly a React hook, the `vanilla` sandbox that provides a clean JS environment is not needed.